### PR TITLE
Add QR code generation to Telegram bot

### DIFF
--- a/bot/bot.ts
+++ b/bot/bot.ts
@@ -13,7 +13,13 @@ const bot = new Telegraf(BOT_TOKEN);
 
 // Start command
 bot.command('start', async (ctx) => {
+    const userId = ctx.from.id;
+    const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=https://xprtrust.com/user/${userId}`;
+    
     await ctx.reply('Welcome to XPR Trusted Bot! 👋');
+    await ctx.replyWithPhoto({ url: qrCodeUrl }, {
+        caption: `Your unique QR code for user ID: ${userId}\nScan to view your profile!`
+    });
 });
 
 // Help command


### PR DESCRIPTION
This PR adds QR code generation to the Telegram bot:

When users start the bot (/start), they receive:
- A welcome message
- A QR code linking to their profile (https://xprtrust.com/user/{userId})
- Their Telegram user ID in the caption